### PR TITLE
ISSUE-3 feat(cart): enable quantity stepper on cart items

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -52,18 +52,14 @@ function handleRemove(_itemId: string): void {
                 <div class="cart-item-controls">
                   <div class="cart-item-quantity">
                     <label class="qty-label">Qty</label>
-                    <!--
-                      Quantity stepper — rendered but not wired to the store.
-                      TODO: Connect to cart.updateQuantity(item.id, newQty)
-                    -->
                     <InputNumber
                       :model-value="item.quantity"
                       :min="1"
                       :max="99"
-                      :disabled="true"
                       show-buttons
                       button-layout="horizontal"
                       :input-style="{ width: '3rem', textAlign: 'center' }"
+                      @update:model-value="(val) => cart.updateQuantity(item.id, val)"
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
Wires the quantity stepper InputNumber component to the Pinia cart store so that changing quantity on any cart item reactively updates subtotal and total.

## Changes
- Remove `:disabled="true"` from `InputNumber` in `pages/index.vue`
- Add `@update:model-value` handler calling `cart.updateQuantity(item.id, val)`
- Remove stale TODO comment

## Test Plan
- [x] All guardrails pass
- [x] `npm test` — 15 Vitest specs pass, 0 failures

Closes #3

---
Agent: learning-java-8675/worker-f02cb1