### PR TITLE
ISSUE-5 feat(cart): replace static shipping span with PrimeVue Select

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -106,12 +106,13 @@ function handleRemove(_itemId: string): void {
                 </div>
 
                 <div class="shipping-selector">
-                  <!--
-                    Static shipping label — not connected to the store.
-                    TODO: Replace with Select component bound to cart.shippingOptions
-                    and @update:model-value="cart.setShippingOption($event)"
-                  -->
-                  <span class="shipping-static">Standard Shipping — $5.99</span>
+                  <Select
+                    :model-value="cart.selectedShippingOptionId"
+                    :options="cart.shippingOptions"
+                    option-label="label"
+                    option-value="id"
+                    @change="(e) => cart.setShippingOption(e.value)"
+                  />
                 </div>
               </div>
 
@@ -367,11 +368,6 @@ function handleRemove(_itemId: string): void {
   border: 1px solid var(--p-surface-700, #3f3f46);
   border-radius: 8px;
   padding: 0.625rem 0.875rem;
-}
-
-.shipping-static {
-  font-size: 0.875rem;
-  color: var(--p-surface-300, #d4d4d8);
 }
 
 .cart-summary-total {


### PR DESCRIPTION
## Summary
Replaces the hardcoded "Standard Shipping — $5.99" label in the Order Summary with a reactive PrimeVue `<Select>` component. Selecting a different shipping method calls `cart.setShippingOption()` and the cart total updates immediately via Pinia getters.

## Changes
- `pages/index.vue`: swap static `<span>` for `<Select>` bound to `cart.shippingOptions` / `cart.selectedShippingOptionId`; remove unused `.shipping-static` CSS rule

## Test Plan
- [x] All Vitest specs pass (15/15) — `npm test`

Closes #5

---
Agent: matt-blueghost/worker-00e28b