### PR TITLE
ISSUE-4 feat(cart): wire remove button to cart.removeFromCart

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,10 +7,7 @@ function formatPrice(price: number): string {
   return price.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 }
 
-// TODO: Connect to cart.removeFromCart(item.id)
-function handleRemove(_itemId: string): void {
-  // no-op — waiting to be connected to the store
-}
+
 </script>
 
 <template>
@@ -72,17 +69,13 @@ function handleRemove(_itemId: string): void {
                       {{ formatPrice(item.price * item.quantity) }}
                     </div>
 
-                    <!--
-                      Remove button — rendered but click handler is a no-op.
-                      TODO: Connect to cart.removeFromCart(item.id)
-                    -->
                     <Button
                       label="✕"
                       severity="danger"
                       variant="text"
                       size="small"
                       aria-label="Remove item"
-                      @click="handleRemove(item.id)"
+                      @click="cart.removeFromCart(item.id)"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
Wires the remove button's `@click` handler to `cart.removeFromCart(item.id)`, enabling item removal from the cart with reactive subtotal and total updates.

## Changes
- Remove no-op `handleRemove` function from `<script setup>`
- Replace `@click="handleRemove(item.id)"` with `@click="cart.removeFromCart(item.id)"` on the remove Button
- Clean up TODO comments for the remove button

## Test Plan
- [x] All Vitest specs pass (15/15)

Closes #4

---
Agent: matt-blueghost/worker-87e44c